### PR TITLE
 Fix stats from being cut off on mobile

### DIFF
--- a/client-vue/src/assets/_mobile.scss
+++ b/client-vue/src/assets/_mobile.scss
@@ -182,7 +182,7 @@
 
     .dashboard-stats {
         font-size: 0.8em;
-        padding-bottom: 10px;
+        padding-bottom: 25px;
     }
 
     .local-videos {


### PR DESCRIPTION
I fixed some things from being cut off while on mobile. I cannot get the other things to cooperate with me, so I'll have to open an issue for the rest #539. Dup of #538 but on `develop-ts` instead of `master`. I also had to close my fix because I noticed that one of my commits also affected the desktop version.