### PR TITLE
Store badge-info tags as a separate field

### DIFF
--- a/common/Comments.ts
+++ b/common/Comments.ts
@@ -85,6 +85,7 @@ export interface TwitchComment {
         bits_spent?: number;
         fragments: TwitchCommentMessageFragment[];
         user_badges: TwitchCommentUserBadge[];
+        user_badge_infos: TwitchCommentUserBadge[];
         user_color: string | null;
         // user_notice_params: unknown; // TODO:
         emoticons: TwitchCommentEmoticons[]; // TODO:

--- a/twitch-chat-dumper/src/TwitchChat.ts
+++ b/twitch-chat-dumper/src/TwitchChat.ts
@@ -779,9 +779,10 @@ export class TwitchChat extends EventEmitter {
             }
         }
 
+        const badge_infos: TwitchCommentUserBadge[] = [];
         if (message.tags?.["badge-info"]) {
             for (const badge in message.tags["badge-info"]) {
-                badges.push({
+                badge_infos.push({
                     "_id": badge,
                     "version": message.tags["badge-info"][badge],
                 });
@@ -809,6 +810,7 @@ export class TwitchChat extends EventEmitter {
                 emoticons: emoticons,
                 fragments: fragments,
                 user_badges: badges || null,
+                user_badge_infos: badge_infos || null,
                 user_color: message.tags?.color || "#FFFFFF",
                 // is_action: message.isAction || false,
             },


### PR DESCRIPTION
badge-info provides additional information about badges and are not separate badges that should be displayed.

This fixes an issue where badges are shown twice in the vod player, but only for new vods.